### PR TITLE
ユーザランククエリ修正

### DIFF
--- a/app/controllers/api/photographs_controller.rb
+++ b/app/controllers/api/photographs_controller.rb
@@ -51,7 +51,7 @@ class Api::PhotographsController < ApiController
   end
 
   def fetch_user_rank
-    @users = User.find(Like.joins(:post).group('posts.user_id').order('count(posts.user_id) desc').limit(5).pluck(:user_id))
+    @users = User.find(Like.joins(:post).group('posts.user_id').order('count(posts.user_id) desc').limit(5).pluck('posts.user_id'))
   end
 
   def fetch_popular_posts

--- a/app/views/home/_footer_menu.html.erb
+++ b/app/views/home/_footer_menu.html.erb
@@ -2,7 +2,7 @@
   <ul class="m-nav">
     <router-link to="/home" tag="li" class="nav-list"><i class="ion-home" aria-hidden="true"></i></router-link>
     <router-link to="/home/all" tag="li" class="nav-list"><i class="ion-search" aria-hidden="true"></i></router-link>
-    <router-link to="/home/<%= current_user.user_name  %>/itinerary" tag="li" class="nav-list"><i class="ion-map" aria-hidden="true"></i></router-link>
+    <router-link to="/home/<%= current_user.try(:user_name)  %>/itinerary" tag="li" class="nav-list"><i class="ion-map" aria-hidden="true"></i></router-link>
     <router-link to="/home/tag" tag="li" class="nav-list"><i class="ion-pricetags" aria-hidden="true"></i></router-link>
   </ul>
 </nav>


### PR DESCRIPTION
### ユーザランクの発行クエリがおかしかったので修正
- 結合した際にuser_idカラムが2つ存在するのが原因っぽい